### PR TITLE
fix: content type for piston execution requests

### DIFF
--- a/src/main/java/com/github/codeboy/piston4j/api/Piston.java
+++ b/src/main/java/com/github/codeboy/piston4j/api/Piston.java
@@ -215,7 +215,7 @@ public class Piston {
                 con.setRequestMethod("POST");
                 if (apiKey != null)
                     con.addRequestProperty("Authorization", apiKey);
-                con.addRequestProperty("Content-Type", "application/" + "POST");
+                con.addRequestProperty("Content-Type", "application/" + "json");
                 con.setDoOutput(true);
                 con.setRequestProperty("User-Agent", "Piston4J");
 


### PR DESCRIPTION
Updated the Content-Type header from "application/POST" to "application/json"

This fixes the error: "requests must be of type application/json" when using the execute method of Piston